### PR TITLE
many-to-manyの実装サンプル

### DIFF
--- a/sql/task5_create_game_table_and_insert_data.sql
+++ b/sql/task5_create_game_table_and_insert_data.sql
@@ -34,7 +34,7 @@ CREATE TABLE platforms
 
 INSERT INTO platforms (platform) VALUES ("PS4");
 INSERT INTO platforms (platform) VALUES ("PS5");
-INSERT INTO platforms (platform) VALUES ("SWITCH");
+INSERT INTO platforms (platform) VALUES ("Switch");
 INSERT INTO platforms (platform) VALUES ("Steam");
 INSERT INTO platforms (platform) VALUES ("Origin");
 INSERT INTO platforms (platform) VALUES ("UBI");

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -1,7 +1,9 @@
 package com.crud_read_and_create.controller;
 
 import java.util.List;
+import java.util.stream.Collectors;
 
+import com.crud_read_and_create.controller.view.GameView;
 import org.apache.commons.lang3.StringUtils;
 import org.apache.commons.lang3.math.NumberUtils;
 import org.springframework.stereotype.Controller;
@@ -46,7 +48,8 @@ public class GameController {
 
 			if (gameForm.getOrder().equals("asc")) {
 				List<Game> gameListAsc = gameService.getGamesAsc();
-				model.addAttribute("gameList", gameListAsc);
+				List<GameView> gameViews = gameListAsc.stream().map(GameView::new).collect(Collectors.toList());;
+				model.addAttribute("gameList", gameViews);
 
 			} else if (gameForm.getOrder().equals("desc")) {
 				List<Game> gameListDesc = gameService.getGamesDesc();

--- a/src/main/java/com/crud_read_and_create/controller/view/GameView.java
+++ b/src/main/java/com/crud_read_and_create/controller/view/GameView.java
@@ -1,0 +1,55 @@
+package com.crud_read_and_create.controller.view;
+
+import com.crud_read_and_create.entity.Game;
+import com.crud_read_and_create.entity.Platform;
+
+import java.util.Comparator;
+import java.util.stream.Collectors;
+
+public class GameView {
+    private String id;
+    private String name;
+    private String genre;
+    private String platforms;
+    private String price;
+
+    public GameView(String id, String title, String genre, String platforms, String price) {
+        this.id = id;
+        this.name = title;
+        this.genre = genre;
+        this.platforms = platforms;
+        this.price = price;
+    }
+
+    public GameView(Game game) {
+        this.id = game.getId();
+        this.name = game.getName();
+        this.genre = game.getGenre();
+        this.platforms = game.getPlatforms().stream()
+                .sorted(Comparator.comparing(Platform::getPlatform))
+                .map(Platform::getPlatform)
+                .collect(Collectors.joining("/"));
+        this.price = String.format("%,d", game.getPrice());
+
+    }
+
+    public String getId() {
+        return id;
+    }
+
+    public String getName() {
+        return name;
+    }
+
+    public String getGenre() {
+        return genre;
+    }
+
+    public String getPlatforms() {
+        return platforms;
+    }
+
+    public String getPrice() {
+        return price;
+    }
+}

--- a/src/main/java/com/crud_read_and_create/entity/Platform.java
+++ b/src/main/java/com/crud_read_and_create/entity/Platform.java
@@ -1,22 +1,23 @@
 package com.crud_read_and_create.entity;
 
 public class Platform {
+
+	private int id;
 	private String platform;
 
-	public Platform(String platform) {
+	public Platform(int id, String platform) {
+		this.id = id;
 		this.platform = platform;
 	}
 
 	public Platform() {
+	}
 
+	public int getId() {
+		return id;
 	}
 
 	public String getPlatform() {
 		return platform;
 	}
-
-	public void setPlatform(String platform) {
-		this.platform = platform;
-	}
-
 }

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -5,20 +5,19 @@
 <mapper namespace="com.crud_read_and_create.mapper.GameMapper">
 	
 	<resultMap type="com.crud_read_and_create.entity.Game" id="gameMap">
-		<id property="games.id" column="games.id"/>
-		<result property="id" column="id" />
+		<result property="id" column="game_id" />
 		<result property="name" column="name" />
 		<result property="genre" column="genre" />
 		<result property="price" column="price" />
 		
 		<collection property="platforms" ofType="com.crud_read_and_create.entity.Platform">
-			<id property="platforms.id" column="platforms.id"/>
-			<result property="platform" column="platform"/>		
+			<id property="id" column="platform_id"/>
+			<result property="platform" column="platform"/>
 		</collection>
 	</resultMap>
 	
     <select id="findAllAsc" resultMap="gameMap">
-        SELECT games.id, name, platform, genre, price 
+        SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
         FROM games
         INNER JOIN games_platforms
  		ON games.id = games_platforms.games_id

--- a/src/main/resources/templates/search/db.html
+++ b/src/main/resources/templates/search/db.html
@@ -30,7 +30,7 @@
             		<td th:text="*{id}">ID</td>
             		<td th:text="*{name}">タイトル</td>
             		<td th:text="*{genre}">ジャンル</td>
-            		<td th:text="*{platform}">プラットフォーム</td>
+            		<td th:text="*{platforms}">プラットフォーム</td>
             		<td th:text="*{price}">価格</td>
         		</tr>  
     		</table>
@@ -48,7 +48,7 @@
             		<td th:text="*{id}">ID</td>
             		<td th:text="*{name}">タイトル</td>
             		<td th:text="*{genre}">ジャンル</td>
-            		<td th:text="*{platform}">プラットフォーム	</td>
+            		<td th:text="*{platforms}">プラットフォーム	</td>
             		<td th:text="*{price}">価格</td>
         		</tr>  
     		</table>


### PR DESCRIPTION
# 概要
`issue-3_review_table-design`ブランチにて #3 を対応してくれていると思います。
`issue-3_review_table-design`からブランチを派生させて1つのゲームに対して複数のプラットフォームを紐付けられるようにしました。

# やったこと
- 1つのゲームに対して複数のプラットフォームが画面に表示されるように実装を修正
- 価格の数字を3桁区切りで表示するように修正
- 任天堂スイッチについてデータベースに登録する値をSWITCHからSwitchに修正

 # 動作確認

`http://localhost:8080/search`にアクセスすると検索画面が表示されることを確認する
<img width="542" alt="スクリーンショット 2022-02-24 14 44 20" src="https://user-images.githubusercontent.com/62045457/155465333-6032e4ba-061b-4f98-ae05-220d5342065a.png">

検索ボタンを押下して`http://localhost:8080/search/db`に遷移することを確認し、以下の表示確認
- 任天堂スイッチはSwitchと表示されること
- WITCHER3のプラットフォームに「Origin/PS4/Steam/Switch」と表示されること
- 各ゲームの価格がすべて3桁区切りで表示されていること

<img width="624" alt="スクリーンショット 2022-02-24 14 44 46" src="https://user-images.githubusercontent.com/62045457/155465368-5d349fe5-d2c9-4c28-85bb-f2a3989d1c05.png">