### PR TITLE
中間テーブルの登録処理の追加

### DIFF
--- a/README.md
+++ b/README.md
@@ -24,7 +24,7 @@
 
 **検索画面**
 
-![task5search](https://user-images.githubusercontent.com/97335620/154416093-2b440f58-1e16-4fff-b64d-f8e7f5db9b8b.png)
+![検索画面](https://user-images.githubusercontent.com/97335620/158062540-e48bf687-e93f-4670-a517-d20f383dd0a3.png)
 
 - 検索条件のIDがnullの場合、全件検索
   - 昇順か降順を選択し、選択に応じ表示する
@@ -33,21 +33,29 @@
 
 **検索結果（昇順全件検索）**
 
-![ascresult](https://user-images.githubusercontent.com/97335620/154419786-58dadc8a-2e2d-4eb2-abf2-1e3369dfc65e.png)
+![検索結果](https://user-images.githubusercontent.com/97335620/158062636-5865077a-5e4e-421d-a7fb-2da0ac568f03.png)
 
-**登録画面**
+**GAME登録画面**
 
-![create](https://user-images.githubusercontent.com/97335620/154419986-7c892c2e-a7a1-4a6a-8799-75fd860a7225.png)
+![登録画面](https://user-images.githubusercontent.com/97335620/158062752-3cedae6e-785f-43e2-b296-aa21b355579a.png)
 
-- 各項目を入力し、登録する
+- 各項目を入力及び選択し、登録する
   - 登録時に入力エラーがあった場合、登録が失敗し、どのエラーが発生したか表示する
+  - プラットフォームを複数登録する場合は、「ctrl + クリック」で選択する
 
 **登録成功時**
 
-![createOK](https://user-images.githubusercontent.com/97335620/154424777-3a2eeebc-ef13-424d-93b4-d850e55defbb.png)
+![登録成功](https://user-images.githubusercontent.com/97335620/158062779-5b1abaf7-0400-4d53-b11f-308f1fae140c.png)
 
 **登録失敗時**
 
-![createNO](https://user-images.githubusercontent.com/97335620/154424877-79a23316-b401-4201-97d7-d6be50bae44d.png)
+![登録失敗](https://user-images.githubusercontent.com/97335620/158062805-2cde9c67-21e2-4b01-b0f0-71afa121e1eb.png)
+
+**PLATFORM登録画面**
+
+![プラットフォーム登録画面](https://user-images.githubusercontent.com/97335620/158063227-70bc07ff-1f45-4445-af77-7309c0192679.png)
+
+- プラットフォームを入力し、登録する
+  - 登録時に入力エラー及び重複していた場合、登録が失敗し、どのエラーが発生したか表示する
 
 （`./gradlew bootRun`コマンドで実行している場合）`ctrl + c`で終了する

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -52,7 +52,7 @@ public class GameController {
 		return "create";
 	}
 
-	@GetMapping("/createPlatform")
+	@GetMapping("/create-platform")
 	public String getCreatePlatform(Model model) {
 		List<Platform> platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
@@ -106,10 +106,10 @@ public class GameController {
 			redirectAttributes.addFlashAttribute("createSuccess", "登録に成功しました。");
 		}
 		redirectAttributes.addFlashAttribute("platformList", platformList);
-		return "redirect:/create";
+		return "redirect:create";
 	}
 
-	@PostMapping("/createPlatform")
+	@PostMapping("/create-platform")
 	public String createPlatform(@Validated PlatformForm platformForm, BindingResult bindingResult, Model model,
 			RedirectAttributes redirectAttributes) {
 
@@ -135,6 +135,6 @@ public class GameController {
 			}
 		}
 		redirectAttributes.addFlashAttribute("platformList", platformList);
-		return "redirect:createPlatform";
+		return "redirect:create-platform";
 	}
 }

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -48,14 +48,14 @@ public class GameController {
 	public String getCreate(Model model) {
 		List<Platform> platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
-		return "/create";
+		return "create";
 	}
 
 	@GetMapping("/createPlatform")
 	public String getCreatePlatform(Model model) {
 		List<Platform> platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
-		return "/createPlatform";
+		return "createPlatform";
 	}
 
 	@PostMapping("/search/db")
@@ -103,7 +103,7 @@ public class GameController {
 		}
 		List<Platform> platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
-		return "/create";
+		return "create";
 	}
 
 	@PostMapping("/createPlatform")
@@ -131,7 +131,7 @@ public class GameController {
 		}
 		platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
-		return "/createPlatform";
+		return "createPlatform";
 	}
 
 }

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -44,7 +44,9 @@ public class GameController {
 	}
 
 	@GetMapping("/create")
-	public String getCreate() {
+	public String getCreate(Model model) {
+		List<Platform> platformList = gameService.getPlatform();
+		model.addAttribute("platformList", platformList);
 		return "/create";
 	}
 
@@ -95,13 +97,12 @@ public class GameController {
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("createFailed", "登録に失敗しました。");
-			return "/create";
-
 		} else {
 			gameService.create(gameForm);
 			model.addAttribute("createSuccess", "登録に成功しました。");
 		}
-
+		List<Platform> platformList = gameService.getPlatform();
+		model.addAttribute("platformList", platformList);
 		return "/create";
 	}
 

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -17,7 +17,8 @@ import com.crud_read_and_create.controller.view.GameView;
 import com.crud_read_and_create.entity.Game;
 import com.crud_read_and_create.entity.Platform;
 import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GameFormPlatform;
+import com.crud_read_and_create.form.GamePlatformForm;
+import com.crud_read_and_create.form.PlatformForm;
 import com.crud_read_and_create.service.GameService;
 
 @Controller
@@ -34,8 +35,8 @@ public class GameController {
 	}
 
 	@ModelAttribute
-	GameFormPlatform setupFormPlatform() {
-		return new GameFormPlatform();
+	PlatformForm setupFormPlatform() {
+		return new PlatformForm();
 	}
 
 	@GetMapping("/search")
@@ -86,19 +87,18 @@ public class GameController {
 			} else {
 				model.addAttribute("mojiretsu", "数字を入力して下さい。");
 			}
-
 		}
-
 		return "search/db";
 	}
 
 	@PostMapping("/create")
-	public String create(@ModelAttribute @Validated GameForm gameForm, BindingResult bindingResult, Model model) {
+	public String create(@ModelAttribute @Validated GameForm gameForm, BindingResult bindingResult,
+			GamePlatformForm gamePlatformForm, Model model) {
 
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("createFailed", "登録に失敗しました。");
 		} else {
-			gameService.create(gameForm);
+			gameService.createGame(gameForm, gamePlatformForm);
 			model.addAttribute("createSuccess", "登録に成功しました。");
 		}
 		List<Platform> platformList = gameService.getPlatform();
@@ -107,8 +107,8 @@ public class GameController {
 	}
 
 	@PostMapping("/createPlatform")
-	public String createPlatform(@ModelAttribute @Validated GameFormPlatform gameFormPlatform,
-			BindingResult bindingResult, Model model) {
+	public String createPlatform(@ModelAttribute @Validated PlatformForm platformForm, BindingResult bindingResult,
+			Model model) {
 
 		List<Platform> platformList = gameService.getPlatform();
 
@@ -117,7 +117,7 @@ public class GameController {
 		} else {
 			boolean check = true;
 			for (int i = 0; i < platformList.size(); i++) {
-				if (gameFormPlatform.getPlatform().equals(platformList.get(i).getPlatform())) {
+				if (platformForm.getPlatform().equals(platformList.get(i).getPlatform())) {
 					check = false;
 					model.addAttribute("createFailed", "登録に失敗しました。");
 					model.addAttribute("duplicate", "プラットフォームが重複しています。");
@@ -125,13 +125,12 @@ public class GameController {
 				}
 			}
 			if (check) {
-				gameService.createPlatform(gameFormPlatform);
+				gameService.createPlatform(platformForm);
 				model.addAttribute("createSuccess", "登録に成功しました。");
 			}
 		}
 		platformList = gameService.getPlatform();
 		model.addAttribute("platformList", platformList);
-
 		return "/createPlatform";
 	}
 

--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -12,6 +12,7 @@ import org.springframework.validation.annotation.Validated;
 import org.springframework.web.bind.annotation.GetMapping;
 import org.springframework.web.bind.annotation.ModelAttribute;
 import org.springframework.web.bind.annotation.PostMapping;
+import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.crud_read_and_create.controller.view.GameView;
 import com.crud_read_and_create.entity.Game;
@@ -92,28 +93,31 @@ public class GameController {
 	}
 
 	@PostMapping("/create")
-	public String create(@ModelAttribute @Validated GameForm gameForm, BindingResult bindingResult,
-			GamePlatformForm gamePlatformForm, Model model) {
+	public String create(@Validated GameForm gameForm, BindingResult bindingResult, GamePlatformForm gamePlatformForm,
+			Model model, RedirectAttributes redirectAttributes) {
 
+		List<Platform> platformList = gameService.getPlatform();
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("createFailed", "登録に失敗しました。");
+			model.addAttribute("platformList", platformList);
+			return "create";
 		} else {
 			gameService.createGame(gameForm, gamePlatformForm);
-			model.addAttribute("createSuccess", "登録に成功しました。");
+			redirectAttributes.addFlashAttribute("createSuccess", "登録に成功しました。");
 		}
-		List<Platform> platformList = gameService.getPlatform();
-		model.addAttribute("platformList", platformList);
-		return "create";
+		redirectAttributes.addFlashAttribute("platformList", platformList);
+		return "redirect:/create";
 	}
 
 	@PostMapping("/createPlatform")
-	public String createPlatform(@ModelAttribute @Validated PlatformForm platformForm, BindingResult bindingResult,
-			Model model) {
+	public String createPlatform(@Validated PlatformForm platformForm, BindingResult bindingResult, Model model,
+			RedirectAttributes redirectAttributes) {
 
 		List<Platform> platformList = gameService.getPlatform();
-
 		if (bindingResult.hasErrors()) {
 			model.addAttribute("createFailed", "登録に失敗しました。");
+			model.addAttribute("platformList", platformList);
+			return "createPlatform";
 		} else {
 			boolean check = true;
 			for (int i = 0; i < platformList.size(); i++) {
@@ -121,17 +125,16 @@ public class GameController {
 					check = false;
 					model.addAttribute("createFailed", "登録に失敗しました。");
 					model.addAttribute("duplicate", "プラットフォームが重複しています。");
-					break;
+					model.addAttribute("platformList", platformList);
+					return "createPlatform";
 				}
 			}
 			if (check) {
 				gameService.createPlatform(platformForm);
-				model.addAttribute("createSuccess", "登録に成功しました。");
+				redirectAttributes.addFlashAttribute("createSuccess", "登録に成功しました。");
 			}
 		}
-		platformList = gameService.getPlatform();
-		model.addAttribute("platformList", platformList);
-		return "createPlatform";
+		redirectAttributes.addFlashAttribute("platformList", platformList);
+		return "redirect:createPlatform";
 	}
-
 }

--- a/src/main/java/com/crud_read_and_create/entity/Platform.java
+++ b/src/main/java/com/crud_read_and_create/entity/Platform.java
@@ -21,6 +21,10 @@ public class Platform {
 		return platform;
 	}
 
+	public String toString() {
+		return platform;
+	}
+
 	public void setId(String id) {
 		this.id = id;
 	}

--- a/src/main/java/com/crud_read_and_create/entity/Platform.java
+++ b/src/main/java/com/crud_read_and_create/entity/Platform.java
@@ -21,8 +21,9 @@ public class Platform {
 		return platform;
 	}
 
+	@Override
 	public String toString() {
-		return platform;
+		return "Platform [id=" + id + ", platform=" + platform + "]";
 	}
 
 	public void setId(String id) {

--- a/src/main/java/com/crud_read_and_create/form/GameForm.java
+++ b/src/main/java/com/crud_read_and_create/form/GameForm.java
@@ -6,9 +6,10 @@ import javax.validation.constraints.NotNull;
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
 
+import com.crud_read_and_create.entity.Platform;
+
 public class GameForm {
 	private String id;
-
 	private String order;
 
 	@Length(max = 20, message = "タイトルは20文字以内で入力して下さい。")
@@ -19,60 +20,59 @@ public class GameForm {
 	@NotBlank(message = "ジャンルが未入力です。")
 	private String genre;
 
-	@Length(max = 20, message = "プラットフォームは20文字以内で入力して下さい。")
-	@NotBlank(message = "プラットフォームが未入力です。")
-	private String platform;
-
 	@Range(min = 0, max = 100000, message = "価格は0~100000の範囲で入力してください。")
 	@NotNull(message = "価格が未入力です。")
 	private Integer price;
 
+//	@NotBlank(message = "プラットフォームが未選択です。")
+	private Platform[] platformId;
+
 	public String getId() {
 		return id;
-	}
-
-	public void setId(String id) {
-		this.id = id;
-	}
-
-	public String getName() {
-		return name;
-	}
-
-	public void setName(String name) {
-		this.name = name;
-	}
-
-	public String getGenre() {
-		return genre;
-	}
-
-	public void setGenre(String genre) {
-		this.genre = genre;
-	}
-
-	public String getPlatform() {
-		return platform;
-	}
-
-	public void setPlatform(String platform) {
-		this.platform = platform;
-	}
-
-	public Integer getPrice() {
-		return price;
-	}
-
-	public void setPrice(Integer price) {
-		this.price = price;
 	}
 
 	public String getOrder() {
 		return order;
 	}
 
+	public String getName() {
+		return name;
+	}
+
+	public String getGenre() {
+		return genre;
+	}
+
+	public Integer getPrice() {
+		return price;
+	}
+
+	public Platform[] getPlatformId() {
+		return platformId;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
 	public void setOrder(String order) {
 		this.order = order;
+	}
+
+	public void setName(String name) {
+		this.name = name;
+	}
+
+	public void setGenre(String genre) {
+		this.genre = genre;
+	}
+
+	public void setPrice(Integer price) {
+		this.price = price;
+	}
+
+	public void setPlatformId(Platform[] platformId) {
+		this.platformId = platformId;
 	}
 
 }

--- a/src/main/java/com/crud_read_and_create/form/GameForm.java
+++ b/src/main/java/com/crud_read_and_create/form/GameForm.java
@@ -2,11 +2,10 @@ package com.crud_read_and_create.form;
 
 import javax.validation.constraints.NotBlank;
 import javax.validation.constraints.NotNull;
+import javax.validation.constraints.Size;
 
 import org.hibernate.validator.constraints.Length;
 import org.hibernate.validator.constraints.Range;
-
-import com.crud_read_and_create.entity.Platform;
 
 public class GameForm {
 	private String id;
@@ -24,8 +23,8 @@ public class GameForm {
 	@NotNull(message = "価格が未入力です。")
 	private Integer price;
 
-//	@NotBlank(message = "プラットフォームが未選択です。")
-	private Platform[] platformId;
+	@Size(min = 1, message = "プラットフォームが未選択です。")
+	private String[] platformId;
 
 	public String getId() {
 		return id;
@@ -47,7 +46,7 @@ public class GameForm {
 		return price;
 	}
 
-	public Platform[] getPlatformId() {
+	public String[] getPlatformId() {
 		return platformId;
 	}
 
@@ -71,7 +70,7 @@ public class GameForm {
 		this.price = price;
 	}
 
-	public void setPlatformId(Platform[] platformId) {
+	public void setPlatformId(String[] platformId) {
 		this.platformId = platformId;
 	}
 

--- a/src/main/java/com/crud_read_and_create/form/GamePlatformForm.java
+++ b/src/main/java/com/crud_read_and_create/form/GamePlatformForm.java
@@ -5,6 +5,12 @@ public class GamePlatformForm {
 	private String gameId;
 	private String platformId;
 
+	public GamePlatformForm(String gameId, String platformId) {
+		super();
+		this.gameId = gameId;
+		this.platformId = platformId;
+	}
+
 	public String getId() {
 		return id;
 	}

--- a/src/main/java/com/crud_read_and_create/form/GamePlatformForm.java
+++ b/src/main/java/com/crud_read_and_create/form/GamePlatformForm.java
@@ -1,0 +1,32 @@
+package com.crud_read_and_create.form;
+
+public class GamePlatformForm {
+	private String id;
+	private String gameId;
+	private String platformId;
+
+	public String getId() {
+		return id;
+	}
+
+	public String getGameId() {
+		return gameId;
+	}
+
+	public String getPlatformId() {
+		return platformId;
+	}
+
+	public void setId(String id) {
+		this.id = id;
+	}
+
+	public void setGameId(String gameId) {
+		this.gameId = gameId;
+	}
+
+	public void setPlatformId(String platformId) {
+		this.platformId = platformId;
+	}
+
+}

--- a/src/main/java/com/crud_read_and_create/form/PlatformForm.java
+++ b/src/main/java/com/crud_read_and_create/form/PlatformForm.java
@@ -4,7 +4,7 @@ import javax.validation.constraints.NotBlank;
 
 import org.hibernate.validator.constraints.Length;
 
-public class GameFormPlatform {
+public class PlatformForm {
 	private String id;
 
 	@Length(max = 20, message = "プラットフォームは20文字以内で入力して下さい。")

--- a/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
+++ b/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
@@ -7,7 +7,8 @@ import org.apache.ibatis.annotations.Mapper;
 import com.crud_read_and_create.entity.Game;
 import com.crud_read_and_create.entity.Platform;
 import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GameFormPlatform;
+import com.crud_read_and_create.form.GamePlatformForm;
+import com.crud_read_and_create.form.PlatformForm;
 
 @Mapper
 public interface GameMapper {
@@ -20,8 +21,10 @@ public interface GameMapper {
 
 	public List<Platform> findPlatform();
 
-	public Integer create(GameForm gameForm);
+	public Integer createGame(GameForm gameForm);
 
-	public Integer createPlatform(GameFormPlatform gameFormPlatform);
+	public Integer createGamePlatform(GamePlatformForm gamePlatformForm);
+
+	public Integer createPlatform(PlatformForm platformForm);
 
 }

--- a/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
+++ b/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
@@ -3,6 +3,7 @@ package com.crud_read_and_create.mapper;
 import java.util.List;
 
 import org.apache.ibatis.annotations.Mapper;
+import org.apache.ibatis.annotations.Param;
 
 import com.crud_read_and_create.entity.Game;
 import com.crud_read_and_create.entity.Platform;
@@ -23,7 +24,7 @@ public interface GameMapper {
 
 	public Integer createGame(GameForm gameForm);
 
-	public Integer createGamePlatform(GamePlatformForm gamePlatformForm);
+	public Integer createGamePlatform(@Param("gamePlatformList") List<GamePlatformForm> gamePlatformList);
 
 	public Integer createPlatform(PlatformForm platformForm);
 

--- a/src/main/java/com/crud_read_and_create/service/GameService.java
+++ b/src/main/java/com/crud_read_and_create/service/GameService.java
@@ -3,11 +3,13 @@ package com.crud_read_and_create.service;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
+import org.springframework.transaction.annotation.Transactional;
 
 import com.crud_read_and_create.entity.Game;
 import com.crud_read_and_create.entity.Platform;
 import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GameFormPlatform;
+import com.crud_read_and_create.form.GamePlatformForm;
+import com.crud_read_and_create.form.PlatformForm;
 import com.crud_read_and_create.mapper.GameMapper;
 
 @Service
@@ -36,11 +38,18 @@ public class GameService {
 		return gameMapper.findPlatform();
 	}
 
-	public int create(GameForm gameForm) {
-		return gameMapper.create(gameForm);
+	@Transactional
+	public void createGame(GameForm gameForm, GamePlatformForm gamePlatformForm) {
+		gameMapper.createGame(gameForm);
+		gamePlatformForm.setGameId(gameForm.getId());
+		String[] platforms = gameForm.getPlatformId();
+		for (String value : platforms) {
+			gamePlatformForm.setPlatformId(value);
+			gameMapper.createGamePlatform(gamePlatformForm);
+		}
 	}
 
-	public int createPlatform(GameFormPlatform gameFormPlatform) {
-		return gameMapper.createPlatform(gameFormPlatform);
+	public int createPlatform(PlatformForm platformForm) {
+		return gameMapper.createPlatform(platformForm);
 	}
 }

--- a/src/main/java/com/crud_read_and_create/service/GameService.java
+++ b/src/main/java/com/crud_read_and_create/service/GameService.java
@@ -1,5 +1,6 @@
 package com.crud_read_and_create.service;
 
+import java.util.ArrayList;
 import java.util.List;
 
 import org.springframework.stereotype.Service;
@@ -41,12 +42,14 @@ public class GameService {
 	@Transactional
 	public void createGame(GameForm gameForm, GamePlatformForm gamePlatformForm) {
 		gameMapper.createGame(gameForm);
-		gamePlatformForm.setGameId(gameForm.getId());
+
+		List<GamePlatformForm> gamePlatformList = new ArrayList<GamePlatformForm>();
 		String[] platforms = gameForm.getPlatformId();
 		for (String value : platforms) {
-			gamePlatformForm.setPlatformId(value);
-			gameMapper.createGamePlatform(gamePlatformForm);
+			GamePlatformForm gpList = new GamePlatformForm(gameForm.getId(), value);
+			gamePlatformList.add(gpList);
 		}
+		gameMapper.createGamePlatform(gamePlatformList);
 	}
 
 	public int createPlatform(PlatformForm platformForm) {

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -65,7 +65,7 @@
     </insert>
     
     <insert id="createGamePlatform">
-		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})	
+		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
 	</insert>
     
 </mapper>

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -70,7 +70,11 @@
 	</insert>
 
 	<insert id="createGamePlatform">
-		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
+		INSERT INTO games_platforms (games_id, platforms_id)
+		VALUES
+		<foreach collection="gamePlatformList" item="list" separator=",">
+			(#{list.gameId}, #{list.platformId})
+		</foreach>
 	</insert>
 
 </mapper>

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -47,8 +47,9 @@
 
 	<select id="findById" resultMap="gameMap">
 		SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
-		FROM games_platforms
-		INNER JOIN games
+		FROM games
+		INNER JOIN
+		games_platforms
 		ON games_platforms.games_id = games.id
 		INNER JOIN platforms
 		ON games_platforms.platforms_id = platforms.id

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -65,7 +65,7 @@
     </insert>
     
     <insert id="createGamePlatform">
-		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
-	</insert>
+    	INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
+    </insert>
     
 </mapper>

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -56,11 +56,16 @@
     	FROM platforms
     </select>
     
-    <insert id="create" useGeneratedKeys="true" keyProperty="id">
-    	INSERT INTO games (name, genre, platform, price) VALUES(#{name}, #{genre}, #{platform}, #{price})   
+    <insert id="createGame" useGeneratedKeys="true" keyProperty="id">
+    	INSERT INTO games (name, genre, price) VALUES(#{name}, #{genre}, #{price}) 
     </insert>
     
     <insert id="createPlatform" useGeneratedKeys="true" keyProperty="id">
     	INSERT INTO platforms (platform) VALUES(#{platform}) 
     </insert>
+    
+    <insert id="createGamePlatform">
+		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})	
+	</insert>
+    
 </mapper>

--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -1,71 +1,75 @@
 <?xml version="1.0" encoding="UTF-8" ?>
 <!DOCTYPE mapper
         PUBLIC "-//mybatis.org//DTD Mapper 3.0//EN"
-        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">   
+        "http://mybatis.org/dtd/mybatis-3-mapper.dtd">
 <mapper namespace="com.crud_read_and_create.mapper.GameMapper">
-	
+
 	<resultMap type="com.crud_read_and_create.entity.Game" id="gameMap">
 		<result property="id" column="game_id" />
 		<result property="name" column="name" />
 		<result property="genre" column="genre" />
 		<result property="price" column="price" />
-		
+
 		<collection property="platforms" ofType="com.crud_read_and_create.entity.Platform">
-			<id property="id" column="platform_id"/>
-			<result property="platform" column="platform"/>		
+			<id property="id" column="platform_id" />
+			<result property="platform" column="platform" />
 		</collection>
 	</resultMap>
-	
+
 	<resultMap type="com.crud_read_and_create.entity.Platform" id="platformMap">
 		<id property="id" column="platform_id" />
 		<result property="platform" column="platform" />
 	</resultMap>
-	
-    <select id="findAllAsc" resultMap="gameMap">
-        SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
-        FROM games
-        INNER JOIN games_platforms
- 		ON games.id = games_platforms.games_id
- 		INNER JOIN platforms
- 		ON games_platforms.platforms_id = platforms.id
- 		ORDER BY games_platforms.id ASC;
-    </select>
-    
-    <select id="findAllDesc" resultMap="gameMap">
-        SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
-        FROM games
-        INNER JOIN games_platforms
- 		ON games.id = games_platforms.games_id
- 		INNER JOIN platforms
- 		ON games_platforms.platforms_id = platforms.id
- 		ORDER BY games_platforms.id DESC;
-    </select>
-    
-    <select id="findById" resultMap="gameMap">
-        SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform 
-        FROM games_platforms
-        INNER JOIN games
- 		ON games_platforms.games_id = games.id
- 		INNER JOIN platforms
- 		ON games_platforms.platforms_id = platforms.id
-        WHERE games_id = #{id} 
-    </select>
-    
-    <select id="findPlatform" resultMap="platformMap">
-    	SELECT platforms.id as platform_id, platform
-    	FROM platforms
-    </select>
-    
-    <insert id="createGame" useGeneratedKeys="true" keyProperty="id">
-    	INSERT INTO games (name, genre, price) VALUES(#{name}, #{genre}, #{price}) 
-    </insert>
-    
-    <insert id="createPlatform" useGeneratedKeys="true" keyProperty="id">
-    	INSERT INTO platforms (platform) VALUES(#{platform}) 
-    </insert>
-    
-    <insert id="createGamePlatform">
-    	INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
-    </insert>
-    
+
+	<select id="findAllAsc" resultMap="gameMap">
+		SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
+		FROM games
+		INNER JOIN
+		games_platforms
+		ON games.id = games_platforms.games_id
+		INNER JOIN platforms
+		ON games_platforms.platforms_id = platforms.id
+		ORDER BY games_platforms.id
+		ASC;
+	</select>
+
+	<select id="findAllDesc" resultMap="gameMap">
+		SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
+		FROM games
+		INNER JOIN
+		games_platforms
+		ON games.id = games_platforms.games_id
+		INNER JOIN platforms
+		ON games_platforms.platforms_id = platforms.id
+		ORDER BY games_platforms.id
+		DESC;
+	</select>
+
+	<select id="findById" resultMap="gameMap">
+		SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
+		FROM games_platforms
+		INNER JOIN games
+		ON games_platforms.games_id = games.id
+		INNER JOIN platforms
+		ON games_platforms.platforms_id = platforms.id
+		WHERE games_id = #{id}
+	</select>
+
+	<select id="findPlatform" resultMap="platformMap">
+		SELECT platforms.id as platform_id, platform
+		FROM platforms
+	</select>
+
+	<insert id="createGame" useGeneratedKeys="true" keyProperty="id">
+		INSERT INTO games (name, genre, price) VALUES(#{name}, #{genre}, #{price})
+	</insert>
+
+	<insert id="createPlatform" useGeneratedKeys="true" keyProperty="id">
+		INSERT INTO platforms (platform) VALUES(#{platform})
+	</insert>
+
+	<insert id="createGamePlatform">
+		INSERT INTO games_platforms (games_id, platforms_id) VALUES(#{gameId}, #{platformId})
+	</insert>
+
 </mapper>

--- a/src/main/resources/static/css/stylesheet.css
+++ b/src/main/resources/static/css/stylesheet.css
@@ -1,126 +1,126 @@
-body{
-    font-family :"Avenir Next";
-    margin : 0;
+body {
+  font-family: "Avenir Next";
+  margin: 0;
 }
 
-header{
-    background-color : #2498B3;
-    color : white;
-    height : 90px;
-    width : 110%;
-    position  : fixed;
-    top : 0;
+header {
+  background-color: #2498B3;
+  color: white;
+  height: 90px;
+  width: 110%;
+  position: fixed;
+  top: 0;
 }
 
-.header-logo{
-    float : left;
-    font-size : 32px;
-    padding : 20px 40px;
+.header-logo {
+  float: left;
+  font-size: 32px;
+  padding: 20px 40px;
 }
 
-ul{
-	list-style : none;
+ul {
+  list-style: none;
 }
 
-.header-list li{
-    float : left;
-    margin : 15px 10px;
+.header-list li {
+  float: left;
+  margin: 15px 10px;
 }
 
-.header-list li:hover{
-    opacity : 0.8;
+.header-list li:hover {
+  opacity: 0.8;
 }
 
-a{
-	color : black;
-	text-decoration : none;
-	padding : 10px 10px;
-	opacity : 1.0;
-    background-color : #a2d729;
-    border-radius : 10px;
-    font-size : 16px;
-    border : 1px solid #1a7940;
+a {
+  color: black;
+  text-decoration: none;
+  padding: 10px 10px;
+  opacity: 1.0;
+  background-color: #a2d729;
+  border-radius: 10px;
+  font-size: 16px;
+  border: 1px solid #1a7940;
 }
 
-a:visited{
-    color: black;
-    text-decoration: none;
+a:visited {
+  color: black;
+  text-decoration: none;
 }
 
-.main{
-    padding : 100px 40px;
+.main {
+  padding: 100px 40px;
 }
 
-.main-logo{
-    color :navy;
-    font-size : 24px;
+.main-logo {
+  color: navy;
+  font-size: 24px;
 }
 
-.btn{
-    margin-top : 10px;
-    margin-bottom : 10px;
-    padding : 6px 18px;
-    color : black;
-    font-size : 18px;
-    background-color : #a2d729;
-    cursor : pointer;
-    box-shadow: 0 5px #1a7940;
+.btn {
+  margin-top: 10px;
+  margin-bottom: 10px;
+  padding: 6px 18px;
+  color: black;
+  font-size: 18px;
+  background-color: #a2d729;
+  cursor: pointer;
+  box-shadow: 0 5px #1a7940;
 }
 
-.btn:active{
-    position : relative;
-    top : 5px;
-    box-shadow : none;
+.btn:active {
+  position: relative;
+  top: 5px;
+  box-shadow: none;
 }
 
-.searchId{
-    padding : 6px;
-    font-size : 12px;
+.searchId {
+  padding: 6px;
+  font-size: 12px;
 }
 
-.createGame{
-	padding : 10px 3px;
-	font-size : 15px;
+.createGame {
+  padding: 10px 3px;
+  font-size: 15px;
 }
 
-.createPlatform{
-	padding : 0 30px 0 10px; 
-	font-size : 15px;
+.createPlatform {
+  padding: 0 30px 0 10px;
+  font-size: 15px;
 }
 
-table{
-	margin : 10px 0;
+table {
+  margin: 10px 0;
 }
 
 table th, table td {
-    border : 1px solid black;
-    padding : 6px;
+  border: 1px solid black;
+  padding: 6px;
 }
 
-.field{
-	background-color : #c0c0c0;
+.field {
+  background-color: #c0c0c0;
 }
 
-.success{
-	color : green;
-	 margin : 10px 0;
-	 font-size : 20px;
+.success {
+  color: green;
+  margin: 10px 0;
+  font-size: 20px;
 }
 
-.exception{
-	 color : red;
-	 margin : 10px 0;
-	 font-size : 20px;
+.exception {
+  color: red;
+  margin: 10px 0;
+  font-size: 20px;
 }
 
-.validation-error{
-	 color : red;
-	 margin-top : 10px;
-	 font-size : 12px;
+.validation-error {
+  color: red;
+  margin-top: 10px;
+  font-size: 12px;
 }
 
-.duplicate-error{
-	 color : red;
-	 margin-top : 10px;
-	 font-size : 12px;
+.duplicate-error {
+  color: red;
+  margin-top: 10px;
+  font-size: 12px;
 }

--- a/src/main/resources/static/css/stylesheet.css
+++ b/src/main/resources/static/css/stylesheet.css
@@ -19,7 +19,7 @@ header{
 }
 
 ul{
-	list-style :none;
+	list-style : none;
 }
 
 .header-list li{
@@ -39,7 +39,7 @@ a{
     background-color : #a2d729;
     border-radius : 10px;
     font-size : 16px;
-    border: 1px solid #1a7940;
+    border : 1px solid #1a7940;
 }
 
 a:visited{
@@ -48,7 +48,7 @@ a:visited{
 }
 
 .main{
-    padding :100px 40px;
+    padding : 100px 40px;
 }
 
 .main-logo{
@@ -58,10 +58,10 @@ a:visited{
 
 .btn{
     margin-top : 10px;
-    margin-bottom :10px;
+    margin-bottom : 10px;
     padding : 6px 18px;
     color : black;
-    font-size: 18px;
+    font-size : 18px;
     background-color : #a2d729;
     cursor : pointer;
     box-shadow: 0 5px #1a7940;
@@ -70,12 +70,22 @@ a:visited{
 .btn:active{
     position : relative;
     top : 5px;
-    box-shadow: none;
+    box-shadow : none;
 }
 
-input{
-    padding: 6px;
-    font-size : 8px;
+.searchId{
+    padding : 6px;
+    font-size : 12px;
+}
+
+.createGame{
+	padding : 10px 3px;
+	font-size : 15px;
+}
+
+.createPlatform{
+	padding : 0 30px 0 10px; 
+	font-size : 15px;
 }
 
 table{
@@ -83,8 +93,8 @@ table{
 }
 
 table th, table td {
-    border: 1px solid black;
-    padding: 6px;
+    border : 1px solid black;
+    padding : 6px;
 }
 
 .field{
@@ -105,12 +115,12 @@ table th, table td {
 
 .validation-error{
 	 color : red;
-	 margin-top :10px;
+	 margin-top : 10px;
 	 font-size : 12px;
 }
 
 .duplicate-error{
 	 color : red;
-	 margin-top :10px;
+	 margin-top : 10px;
 	 font-size : 12px;
 }

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -1,51 +1,49 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  	<meta charset="UTF-8"></meta>
-  	<link th:href = "@{/css/stylesheet.css}" rel = "stylesheet">
-	<title>GameSearch</title>
+<meta charset="UTF-8"></meta>
+<link th:href="@{/css/stylesheet.css}" rel="stylesheet">
+<title>GameSearch</title>
 </head>
 <body>
-	<header>
-		<div class = "header-logo">GAMEの検索と登録</div>
-		<div class = "header-list">
-			<ul>
-	    		<li><a th:href="@{/search}">検索条件</a></li>
-	    		<li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
-			</ul>
-		</div>
-	</header>
-	<div class = "main">
-		<div class = "main-logo">新規登録</div>
-		<form method="post" th:action="@{/create}" th:object="${gameForm}">
-			<table>
-    			<tr class = "field">
-            		<th>タイトル</th>
-            		<th>ジャンル</th>
-            		<th>プラットフォーム</th>
-            		<th>価格</th>
-        		</tr>
-        		<tr>
-            		<td><input class="createGame" type="text" name="name" th:value="${name_value}"></td>
-            		<td><input class="createGame" type="text" name="genre" th:value="${genre_value}"></td>
-            		<td>
-            			<select th:field="*{platformId}" id="multiSelect" name="platformId" multiple size=4>
-            				<option class="createPlatform" th:each="platform:${platformList}" th:value="${platform.id}" th:text="${platform.platform}"></option>
-            			</select>
-            		</td>
-            		<td><input class="createGame" type="number" name="price" th:value="${price_value}"></td>
-        		</tr>
-        	</table>  
-        	<input class="btn" type="submit" value="登録">
-        	<div class="success" th:text = "${createSuccess}"></div>
-        	<div class="exception" th:text = "${createFailed}"></div>
-        	<div class="validation-error">
-        		<p th:errors="*{name}"></p>
-        		<p th:errors="*{genre}"></p>
-        		<p th:errors="*{platformId}"></p>
-        		<p th:errors="*{price}"></p>
-        	</div>
-  		</form>
-	</div>
+    <header>
+        <div class="header-logo">GAMEの検索と登録</div>
+        <div class="header-list">
+            <ul>
+                <li><a th:href="@{/search}">検索条件</a></li>
+                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+            </ul>
+        </div>
+    </header>
+    <div class="main">
+        <div class="main-logo">新規登録</div>
+        <form method="post" th:action="@{/create}" th:object="${gameForm}">
+            <table>
+                <tr class="field">
+                    <th>タイトル</th>
+                    <th>ジャンル</th>
+                    <th>プラットフォーム</th>
+                    <th>価格</th>
+                </tr>
+                <tr>
+                    <td><input class="createGame" type="text" name="name" th:value="${name_value}"></td>
+                    <td><input class="createGame" type="text" name="genre" th:value="${genre_value}"></td>
+                    <td><select th:field="*{platformId}" id="multiSelect" name="platformId" multiple size=4>
+                            <option class="createPlatform" th:each="platform:${platformList}" th:value="${platform.id}" th:text="${platform.platform}"></option>
+                    </select></td>
+                    <td><input class="createGame" type="number" name="price" th:value="${price_value}"></td>
+                </tr>
+            </table>
+            <input class="btn" type="submit" value="登録">
+            <div class="success" th:text="${createSuccess}"></div>
+            <div class="exception" th:text="${createFailed}"></div>
+            <div class="validation-error">
+                <p th:errors="*{name}"></p>
+                <p th:errors="*{genre}"></p>
+                <p th:errors="*{platformId}"></p>
+                <p th:errors="*{price}"></p>
+            </div>
+        </form>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -11,7 +11,7 @@
         <div class="header-list">
             <ul>
                 <li><a th:href="@{/search}">検索条件</a></li>
-                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+                <li><a th:href="@{/create-platform}">PLATFORM登録</a></li>
             </ul>
         </div>
     </header>

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -28,7 +28,12 @@
         		<tr>
             		<td><input type="text" name="name" th:value="${name_value}"></td>
             		<td><input type="text" name="genre" th:value="${genre_value}"></td>
-            		<td><input type="text" name="platform" th:value="${platform_value}"></td>
+            		<td>
+            			<select th:field="*{platformId}" id="multiSelect" name="platformId" multiple>
+            				<option th:each="platform:${platformList}" th:value="${id}" th:text="${platform}"></option>
+            			</select>
+            		</td>
+            		<!-- <td><input type="text" name="platform" th:value="${platform_value}"></td> -->
             		<td><input type="number" name="price" th:value="${price_value}"></td>
         		</tr>
         	</table>  
@@ -38,7 +43,7 @@
         	<div class="validation-error">
         		<p th:errors="*{name}"></p>
         		<p th:errors="*{genre}"></p>
-        		<p th:errors="*{platform}"></p>
+        		<p th:errors="*{platformId}"></p>
         		<p th:errors="*{price}"></p>
         	</div>
   		</form>

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -30,7 +30,7 @@
             		<td><input class="createGame" type="text" name="genre" th:value="${genre_value}"></td>
             		<td>
             			<select th:field="*{platformId}" id="multiSelect" name="platformId" multiple size=4>
-            				<option class="createPlatform" th:each="platform:${platformList}" th:value="${platform.id}" th:text="${platform}"></option>
+            				<option class="createPlatform" th:each="platform:${platformList}" th:value="${platform.id}" th:text="${platform.platform}"></option>
             			</select>
             		</td>
             		<td><input class="createGame" type="number" name="price" th:value="${price_value}"></td>

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -37,12 +37,12 @@
             <input class="btn" type="submit" value="登録">
             <div class="success" th:text="${createSuccess}"></div>
             <div class="exception" th:text="${createFailed}"></div>
-            <div class="validation-error">
+            <div class="validation-error">          
                 <p th:errors="*{name}"></p>
                 <p th:errors="*{genre}"></p>
                 <p th:errors="*{platformId}"></p>
                 <p th:errors="*{price}"></p>
-            </div>
+            </div>    
         </form>
     </div>
 </body>

--- a/src/main/resources/templates/create.html
+++ b/src/main/resources/templates/create.html
@@ -26,15 +26,14 @@
             		<th>価格</th>
         		</tr>
         		<tr>
-            		<td><input type="text" name="name" th:value="${name_value}"></td>
-            		<td><input type="text" name="genre" th:value="${genre_value}"></td>
+            		<td><input class="createGame" type="text" name="name" th:value="${name_value}"></td>
+            		<td><input class="createGame" type="text" name="genre" th:value="${genre_value}"></td>
             		<td>
-            			<select th:field="*{platformId}" id="multiSelect" name="platformId" multiple>
-            				<option th:each="platform:${platformList}" th:value="${id}" th:text="${platform}"></option>
+            			<select th:field="*{platformId}" id="multiSelect" name="platformId" multiple size=4>
+            				<option class="createPlatform" th:each="platform:${platformList}" th:value="${platform.id}" th:text="${platform}"></option>
             			</select>
             		</td>
-            		<!-- <td><input type="text" name="platform" th:value="${platform_value}"></td> -->
-            		<td><input type="number" name="price" th:value="${price_value}"></td>
+            		<td><input class="createGame" type="number" name="price" th:value="${price_value}"></td>
         		</tr>
         	</table>  
         	<input class="btn" type="submit" value="登録">

--- a/src/main/resources/templates/createPlatform.html
+++ b/src/main/resources/templates/createPlatform.html
@@ -1,51 +1,51 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  	<meta charset="UTF-8"></meta>
-  	<link th:href = "@{/css/stylesheet.css}" rel = "stylesheet">
-	<title>GameSearch</title>
+<meta charset="UTF-8"></meta>
+<link th:href="@{/css/stylesheet.css}" rel="stylesheet">
+<title>GameSearch</title>
 </head>
 <body>
-	<header>
-		<div class = "header-logo">GAMEの検索と登録</div>
-		<div class = "header-list">
-			<ul>
-	    		<li><a th:href="@{/search}">検索条件</a></li>
-	    		<li><a th:href="@{/create}">GAME登録</a></li>
-			</ul>
-		</div>
-	</header>
-	<div class = "main">
-		<div class = "main-logo">新規登録</div>
-		<form method="post" th:action="@{/createPlatform}" th:object="${platformForm}">
-			<table>
-    			<tr class = "field">
-            		<th>プラットフォーム</th>
-        		</tr>
-        		<tr>
-            		<td><input class="createGame" type="text" name="platform" th:value="${platform_value}"></td>
-        		</tr>
-        	</table>  
-        	<input class="btn" type="submit" value="登録">
-        	<div class="success" th:text = "${createSuccess}"></div>
-        	<div class="exception" th:text = "${createFailed}"></div>
-        	<div class="duplicate-error" th:text = "${duplicate}"></div>
-        	<div class="validation-error">
-        		<p th:errors="*{platform}"></p>
-        	</div>
-  		</form>
-  		<div th:if = "${platformList} != null">
-    	<table>
-    		<tr class = "field">
-    			<th>ID</th>
-            	<th>プラットフォーム</th>
-        	</tr>
-        	<tr th:each="platformCheck:${platformList}" th:object="${platformCheck}">
-            	<td th:text="*{id}">ID</td>
-            	<td th:text="*{platform}">プラットフォーム</td>
-        	</tr>
-    	</table>
-     	</div>
-	</div>
+    <header>
+        <div class="header-logo">GAMEの検索と登録</div>
+        <div class="header-list">
+            <ul>
+                <li><a th:href="@{/search}">検索条件</a></li>
+                <li><a th:href="@{/create}">GAME登録</a></li>
+            </ul>
+        </div>
+    </header>
+    <div class="main">
+        <div class="main-logo">新規登録</div>
+        <form method="post" th:action="@{/createPlatform}" th:object="${platformForm}">
+            <table>
+                <tr class="field">
+                    <th>プラットフォーム</th>
+                </tr>
+                <tr>
+                    <td><input class="createGame" type="text" name="platform" th:value="${platform_value}"></td>
+                </tr>
+            </table>
+            <input class="btn" type="submit" value="登録">
+            <div class="success" th:text="${createSuccess}"></div>
+            <div class="exception" th:text="${createFailed}"></div>
+            <div class="duplicate-error" th:text="${duplicate}"></div>
+            <div class="validation-error">
+                <p th:errors="*{platform}"></p>
+            </div>
+        </form>
+        <div th:if="${platformList} != null">
+            <table>
+                <tr class="field">
+                    <th>ID</th>
+                    <th>プラットフォーム</th>
+                </tr>
+                <tr th:each="platformCheck:${platformList}" th:object="${platformCheck}">
+                    <td th:text="*{id}">ID</td>
+                    <td th:text="*{platform}">プラットフォーム</td>
+                </tr>
+            </table>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/createPlatform.html
+++ b/src/main/resources/templates/createPlatform.html
@@ -17,7 +17,7 @@
     </header>
     <div class="main">
         <div class="main-logo">新規登録</div>
-        <form method="post" th:action="@{/createPlatform}" th:object="${platformForm}">
+        <form method="post" th:action="@{/create-platform}" th:object="${platformForm}">
             <table>
                 <tr class="field">
                     <th>プラットフォーム</th>

--- a/src/main/resources/templates/createPlatform.html
+++ b/src/main/resources/templates/createPlatform.html
@@ -17,13 +17,13 @@
 	</header>
 	<div class = "main">
 		<div class = "main-logo">新規登録</div>
-		<form method="post" th:action="@{/createPlatform}" th:object="${gameFormPlatform}">
+		<form method="post" th:action="@{/createPlatform}" th:object="${platformForm}">
 			<table>
     			<tr class = "field">
             		<th>プラットフォーム</th>
         		</tr>
         		<tr>
-            		<td><input type="text" name="platform" th:value="${platform_value}"></td>
+            		<td><input class="createGame" type="text" name="platform" th:value="${platform_value}"></td>
         		</tr>
         	</table>  
         	<input class="btn" type="submit" value="登録">

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -21,7 +21,7 @@
 			 <table>
 			 	<tr>
 			 		<th>ID</th>
-			 		<th><input type="text" name="id" th:value="${id_value}"></th>		 		
+			 		<th><input class = "searchId" type="text" name="id" th:value="${id_value}"></th>		 		
   			 	</tr>
 			 </table>
 			 <div>

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -11,7 +11,7 @@
         <div class="header-list">
             <ul>
                 <li><a th:href="@{/create}">GAME登録</a></li>
-                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+                <li><a th:href="@{/create-platform}">PLATFORM登録</a></li>
             </ul>
         </div>
     </header>

--- a/src/main/resources/templates/search.html
+++ b/src/main/resources/templates/search.html
@@ -1,37 +1,34 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  	<meta charset="UTF-8"></meta>
-  	<link th:href = "@{/css/stylesheet.css}" rel = "stylesheet">
-	<title>GameSearch</title>
+<meta charset="UTF-8"></meta>
+<link th:href="@{/css/stylesheet.css}" rel="stylesheet">
+<title>GameSearch</title>
 </head>
 <body>
-	<header>
-		<div class = "header-logo">GAMEの検索と登録</div>
-		<div class = "header-list">
-			<ul>
-	    		<li><a th:href="@{/create}">GAME登録</a></li>
-	    		<li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
-			</ul>
-		</div>
-	</header>
-	<div class = "main">
-		<form method="post" th:action="@{/search/db}">
-			 <div class = "main-logo">検索条件</div>
-			 <table>
-			 	<tr>
-			 		<th>ID</th>
-			 		<th><input class = "searchId" type="text" name="id" th:value="${id_value}"></th>		 		
-  			 	</tr>
-			 </table>
-			 <div>
-			 	<input type="radio" id="asc" name="order" value="asc" checked>
-			 	<label for="asc">昇順</label>			 
-			 	<input type="radio" id="desc" name="order" value="desc">
-			 	<label for="desc">降順</label>			 
-			 </div>	
-    		 <input class="btn" type="submit" value="検索">
-  		</form>
-	</div>
+    <header>
+        <div class="header-logo">GAMEの検索と登録</div>
+        <div class="header-list">
+            <ul>
+                <li><a th:href="@{/create}">GAME登録</a></li>
+                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+            </ul>
+        </div>
+    </header>
+    <div class="main">
+        <form method="post" th:action="@{/search/db}">
+            <div class="main-logo">検索条件</div>
+            <table>
+                <tr>
+                    <th>ID</th>
+                    <th><input class="searchId" type="text" name="id" th:value="${id_value}"></th>
+                </tr>
+            </table>
+            <div>
+                <input type="radio" id="asc" name="order" value="asc" checked> <label for="asc">昇順</label> <input type="radio" id="desc" name="order" value="desc"> <label for="desc">降順</label>
+            </div>
+            <input class="btn" type="submit" value="検索">
+        </form>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/search/db.html
+++ b/src/main/resources/templates/search/db.html
@@ -1,45 +1,45 @@
 <!DOCTYPE html>
 <html xmlns:th="http://www.thymeleaf.org">
 <head>
-  <meta charset="UTF-8"></meta>
-  <link th:href = "@{/css/stylesheet.css}" rel = "stylesheet">
-  <title>GameSearch</title>
+<meta charset="UTF-8"></meta>
+<link th:href="@{/css/stylesheet.css}" rel="stylesheet">
+<title>GameSearch</title>
 </head>
 <body>
-  <header>
-	<div class = "header-logo">GAMEの検索と登録</div>
-	<div class = "header-list">
-		<ul>
-			<li><a th:href="@{/search}">検索条件</a></li>
-	    	<li><a th:href="@{/create}">GAME登録</a></li>
-	    	<li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
-		</ul>
-	</div>
-  </header>
-	<div class = main>
-		<div class = "main-logo">検索結果</div>
-  			<div th:if = "${gameList} != null">
-    		<table>
-    			<tr class = "field">
-    				<th>ID</th>
-            		<th>タイトル</th>
-            		<th>ジャンル</th>
-            		<th>プラットフォーム</th>
-            		<th>価格</th>
-        		</tr>
-        		<tr th:each = "game:${gameList}" th:object = "${game}">
-            		<td th:text="*{id}">ID</td>
-            		<td th:text="*{name}">タイトル</td>
-            		<td th:text="*{genre}">ジャンル</td>
-            		<td th:text="*{platforms}">プラットフォーム</td>
-            		<td th:text="*{price}">価格</td>
-        		</tr>  
-    		</table>
-     	 	</div>
-    	 <div class = exception> 
-    	 	<div th:text = "${notFound}"></div>
-    	  	<div th:text = "${mojiretsu}"></div>
-    	 </div>
-    </div>  
+    <header>
+        <div class="header-logo">GAMEの検索と登録</div>
+        <div class="header-list">
+            <ul>
+                <li><a th:href="@{/search}">検索条件</a></li>
+                <li><a th:href="@{/create}">GAME登録</a></li>
+                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+            </ul>
+        </div>
+    </header>
+    <div class=main>
+        <div class="main-logo">検索結果</div>
+        <div th:if="${gameList} != null">
+            <table>
+                <tr class="field">
+                    <th>ID</th>
+                    <th>タイトル</th>
+                    <th>ジャンル</th>
+                    <th>プラットフォーム</th>
+                    <th>価格</th>
+                </tr>
+                <tr th:each="game:${gameList}" th:object="${game}">
+                    <td th:text="*{id}">ID</td>
+                    <td th:text="*{name}">タイトル</td>
+                    <td th:text="*{genre}">ジャンル</td>
+                    <td th:text="*{platforms}">プラットフォーム</td>
+                    <td th:text="*{price}">価格</td>
+                </tr>
+            </table>
+        </div>
+        <div class=exception>
+            <div th:text="${notFound}"></div>
+            <div th:text="${mojiretsu}"></div>
+        </div>
+    </div>
 </body>
 </html>

--- a/src/main/resources/templates/search/db.html
+++ b/src/main/resources/templates/search/db.html
@@ -12,7 +12,7 @@
             <ul>
                 <li><a th:href="@{/search}">検索条件</a></li>
                 <li><a th:href="@{/create}">GAME登録</a></li>
-                <li><a th:href="@{/createPlatform}">PLATFORM登録</a></li>
+                <li><a th:href="@{/create-platform}">PLATFORM登録</a></li>
             </ul>
         </div>
     </header>


### PR DESCRIPTION
# 概要
中間テーブルの登録処理を追加し、1つのゲームに対し、複数のプラットフォームを登録できるように修正しました。

# やったこと
- 中間テーブルの登録処理の追加
- プラットフォームを複数登録できるように修正
-  ゲーム登録～中間テーブル登録にトランザクションを張った
   -  中間テーブル登録前で例外を投げ、ロールバックされていることを確認
 
# 動作確認
`http://localhost:8080/search`にアクセスすると検索画面が表示されることを確認する。

![検索画面](https://user-images.githubusercontent.com/97335620/158064494-3d8e89e7-3882-4d1a-a71c-42e2cba6f79c.png)

GAME登録ボタンを押下して`http://localhost:8080/create`に遷移し、各項目を入力、及び選択する。

![登録画面ELDENRING](https://user-images.githubusercontent.com/97335620/158065070-5d1292a8-e9f1-4b3b-8200-4394dc6eca86.png)

検索条件ボタンを押下して`http://localhost:8080/search`に遷移する。
検索ボタンを押下して`http://localhost:8080/search/db`に遷移し、GAME登録画面で入力した内容が登録されていることを確認する。

![ELDENRING登録確認](https://user-images.githubusercontent.com/97335620/158065582-c979f574-312d-4e68-9915-4d9c166caecf.png)

# 参考資料
https://qiita.com/curry__30/items/4af9d94e42a050b87254
https://arakan-pgm-ai.hatenablog.com/entry/2017/03/18/230802
