### PR TITLE
ドメイン層のFormとの依存関係を削除 #17

### DIFF
--- a/src/main/java/com/crud_read_and_create/controller/GameController.java
+++ b/src/main/java/com/crud_read_and_create/controller/GameController.java
@@ -13,7 +13,6 @@ import org.springframework.web.servlet.mvc.support.RedirectAttributes;
 
 import com.crud_read_and_create.entity.Platform;
 import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GamePlatformForm;
 import com.crud_read_and_create.form.PlatformForm;
 import com.crud_read_and_create.service.GameService;
 import com.crud_read_and_create.service.exception.DuplicateException;
@@ -60,7 +59,7 @@ public class GameController {
 	@PostMapping("/search/db")
 	public String search(GameForm gameForm, Model model) {
 		try {
-			model.addAttribute("gameList", gameService.getGames(gameForm));
+			model.addAttribute("gameList", gameService.getGames(gameForm.getId(), gameForm.getOrder()));
 		} catch (NotFoundException e) {
 			model.addAttribute("notFound", "レコードは存在しませんでした。");
 		} catch (PatternIntException e) {
@@ -70,8 +69,8 @@ public class GameController {
 	}
 
 	@PostMapping("/create")
-	public String create(@Validated GameForm gameForm, BindingResult bindingResult, GamePlatformForm gamePlatformForm,
-			Model model, RedirectAttributes redirectAttributes) {
+	public String create(@Validated GameForm gameForm, BindingResult bindingResult, Model model,
+			RedirectAttributes redirectAttributes) {
 
 		List<Platform> platformList = gameService.getPlatform();
 		if (bindingResult.hasErrors()) {
@@ -79,7 +78,8 @@ public class GameController {
 			model.addAttribute("platformList", platformList);
 			return "create";
 		} else {
-			gameService.createGame(gameForm, gamePlatformForm);
+			gameService.createGame(gameForm.getId(), gameForm.getName(), gameForm.getGenre(), gameForm.getPrice(),
+					gameForm.getPlatformId());
 			redirectAttributes.addFlashAttribute("createSuccess", "登録に成功しました。");
 			redirectAttributes.addFlashAttribute("platformList", platformList);
 		}
@@ -97,7 +97,8 @@ public class GameController {
 		} else {
 			try {
 				redirectAttributes.addFlashAttribute("createSuccess", "登録に成功しました。");
-				redirectAttributes.addFlashAttribute("platformList", gameService.createPlatform(platformForm));
+				redirectAttributes.addFlashAttribute("platformList",
+						gameService.createPlatform(platformForm.getId(), platformForm.getPlatform()));
 			} catch (DuplicateException e) {
 				model.addAttribute("createFailed", "登録に失敗しました。");
 				model.addAttribute("duplicate", "プラットフォームが重複しています。");

--- a/src/main/java/com/crud_read_and_create/entity/GamePlatform.java
+++ b/src/main/java/com/crud_read_and_create/entity/GamePlatform.java
@@ -1,12 +1,11 @@
-package com.crud_read_and_create.form;
+package com.crud_read_and_create.entity;
 
-public class GamePlatformForm {
+public class GamePlatform {
 	private String id;
 	private String gameId;
 	private String platformId;
 
-	public GamePlatformForm(String gameId, String platformId) {
-		super();
+	public GamePlatform(String gameId, String platformId) {
 		this.gameId = gameId;
 		this.platformId = platformId;
 	}

--- a/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
+++ b/src/main/java/com/crud_read_and_create/mapper/GameMapper.java
@@ -6,10 +6,8 @@ import org.apache.ibatis.annotations.Mapper;
 import org.apache.ibatis.annotations.Param;
 
 import com.crud_read_and_create.entity.Game;
+import com.crud_read_and_create.entity.GamePlatform;
 import com.crud_read_and_create.entity.Platform;
-import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GamePlatformForm;
-import com.crud_read_and_create.form.PlatformForm;
 import com.crud_read_and_create.service.OrderBy;
 
 @Mapper
@@ -21,10 +19,10 @@ public interface GameMapper {
 
 	public List<Platform> findPlatform();
 
-	public Integer createGame(GameForm gameForm);
+	public Integer createGame(Game game);
 
-	public Integer createGamePlatform(@Param("gamePlatformList") List<GamePlatformForm> gamePlatformList);
+	public Integer createGamePlatform(@Param("gamePlatformList") List<GamePlatform> gamePlatformList);
 
-	public Integer createPlatform(PlatformForm platformForm);
+	public Integer createPlatform(@Param("id") String id, @Param("platform") String platform);
 
 }

--- a/src/main/java/com/crud_read_and_create/service/GameService.java
+++ b/src/main/java/com/crud_read_and_create/service/GameService.java
@@ -11,10 +11,8 @@ import org.springframework.transaction.annotation.Transactional;
 
 import com.crud_read_and_create.controller.view.GameView;
 import com.crud_read_and_create.entity.Game;
+import com.crud_read_and_create.entity.GamePlatform;
 import com.crud_read_and_create.entity.Platform;
-import com.crud_read_and_create.form.GameForm;
-import com.crud_read_and_create.form.GamePlatformForm;
-import com.crud_read_and_create.form.PlatformForm;
 import com.crud_read_and_create.mapper.GameMapper;
 import com.crud_read_and_create.service.exception.DuplicateException;
 import com.crud_read_and_create.service.exception.NotFoundException;
@@ -28,15 +26,15 @@ public class GameService {
 		this.gameMapper = gameMapper;
 	}
 
-	public List<GameView> getGames(GameForm gameForm) throws NotFoundException, PatternIntException {
+	public List<GameView> getGames(String Id, String order) throws NotFoundException, PatternIntException {
 
 		List<GameView> gameView = new ArrayList<GameView>();
-		if (StringUtils.isEmpty(gameForm.getId())) {
-			List<Game> gameList = gameMapper.findAll(OrderBy.from(gameForm.getOrder()));
+		if (StringUtils.isEmpty(Id)) {
+			List<Game> gameList = gameMapper.findAll(OrderBy.from(order));
 			gameView = gameList.stream().map(GameView::new).collect(Collectors.toList());
 		} else {
-			if (NumberUtils.isNumber(gameForm.getId())) {
-				List<Game> gameId = gameMapper.findById(gameForm.getId());
+			if (NumberUtils.isNumber(Id)) {
+				List<Game> gameId = gameMapper.findById(Id);
 				if (gameId.size() == 0) {
 					throw new NotFoundException("レコードは存在しませんでした。");
 				} else {
@@ -54,25 +52,29 @@ public class GameService {
 	}
 
 	@Transactional
-	public void createGame(GameForm gameForm, GamePlatformForm gamePlatformForm) {
-		gameMapper.createGame(gameForm);
-
-		List<GamePlatformForm> gamePlatformList = new ArrayList<GamePlatformForm>();
-		String[] platforms = gameForm.getPlatformId();
-		for (String value : platforms) {
-			GamePlatformForm gpList = new GamePlatformForm(gameForm.getId(), value);
+	public void createGame(String id, String name, String genre, Integer price, String[] platformId) {
+		// 登録するGameの各値を詰め込む（中間テーブルに登録するgameIdを取得するために使用）
+		Game game = new Game();
+		game.setId(id);
+		game.setName(name);
+		game.setGenre(genre);
+		game.setPrice(price);
+		gameMapper.createGame(game);
+		List<GamePlatform> gamePlatformList = new ArrayList<GamePlatform>();
+		for (String value : platformId) {
+			GamePlatform gpList = new GamePlatform(game.getId(), value);
 			gamePlatformList.add(gpList);
 		}
 		gameMapper.createGamePlatform(gamePlatformList);
 	}
 
-	public int createPlatform(PlatformForm platformForm) throws DuplicateException {
+	public int createPlatform(String id, String platform) throws DuplicateException {
 		List<Platform> platformList = gameMapper.findPlatform();
 		for (int i = 0; i < platformList.size(); i++) {
-			if (platformForm.getPlatform().equals(platformList.get(i).getPlatform())) {
+			if (platform.equals(platformList.get(i).getPlatform())) {
 				throw new DuplicateException("プラットフォームが重複しています。");
 			}
 		}
-		return gameMapper.createPlatform(platformForm);
+		return gameMapper.createPlatform(id, platform);
 	}
 }


### PR DESCRIPTION
# 概要
ServiceとMapperのFormとの依存関係を削除しました。

# やったこと
- GamePlatformクラスを作成し、GamePlatformFormクラスが不要となったため、GamePlatformFormクラスは削除しました。
- 中間テーブルに登録するgameIdを取得するために、ゲームの登録のみGameインスタンスを生成してから、登録しています。

# やってないこと
- プラットフォームの登録はPlatformインスタンスを生成せず、各引数をそのまま使用して登録しています。