### PR TITLE
xmlファイルのSQL文を一時的にフォーマッターを無効にして整形

### DIFF
--- a/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/GameMapper.xml
@@ -15,7 +15,7 @@
             <result property="platform" column="platform"/>
         </collection>
     </resultMap>
-    
+
     <select id="findAll" resultMap="gameMap">
         SELECT games.id as game_id, name, genre, price, platforms.id as platform_id, platform
         FROM games
@@ -57,8 +57,7 @@
         games_platforms, games
         FROM games_platforms INNER JOIN games
         ON games_platforms.games_id = games.id
-        WHERE games.id =
-        #{id}
+        WHERE games.id = #{id}
     </delete>
 
     <delete id="deleteGame">

--- a/src/main/resources/com/crud_read_and_create/mapper/PlatformMapper.xml
+++ b/src/main/resources/com/crud_read_and_create/mapper/PlatformMapper.xml
@@ -43,8 +43,7 @@
         games_platforms, platforms
         FROM games_platforms INNER JOIN platforms
         ON games_platforms.platforms_id = platforms.id
-        WHERE platforms.id =
-        #{id}
+        WHERE platforms.id = #{id}
     </delete>
 
     <delete id="deletePlatform">


### PR DESCRIPTION
# 概要
xmlファイルのSQL文がフォーマッターにより、不要なところで改行されていたため、一時的にフォーマッターをオフにして整形しました。
[こちらの指摘](https://github.com/renangton/task5_crud_read_and_create/pull/25#discussion_r884261143)に対する修正です。

# やっていないこと
フォーマッターにより不要な改行がされている部分が、何が原因で改行されているか分からなかったため、フォーマッターの設定は修正できていません。